### PR TITLE
use hostColocation to keep entire parallel path on a single host

### DIFF
--- a/StreamsEmailBenchmark/Main.splmm
+++ b/StreamsEmailBenchmark/Main.splmm
@@ -111,55 +111,32 @@ composite StreamParallelizer(output out) {
 	<%for(my $i=0; $i<$parallelism; ++$i) {%>
     (stream<blob Avro> avroBinary<%=$i%>) = FileSource() {
     	param	format				: bin;
-				compression			: gzip;
+//				compression			: gzip;
 				readPunctuations	: true;
 				file				: getSubmissionTimeValue("filename") + "<%=$i%>.av";
-//		config	placement			: partitionColocation("FileSource<%=$i%>");
-		config	placement			: partitionColocation("SourceDecodeFilterBin<%=$i%>");
+		config	placement			: partitionColocation("FileSource<%=$i%>"), hostColocation("StreamParallelizer<%=$i%>");
+//		config	placement			: partitionColocation("SourceDecodeFilterBin<%=$i%>"), hostColocation("StreamParallelizer<%=$i%>");
 	}
 
-	(stream<emailTuple> emailStream<%=$i%>) = avroDecode(avroBinary<%=$i%>) {
+    @parallel(width=5)
+	(stream<emailBin> encodedEmail<%=$i%>; stream<emailMetrics> metricsOut<%=$i%>) = doTheWork(avroBinary<%=$i%>) {
 //		config	placement			: partitionColocation("decode<%=$i%>");
-		config	placement			: partitionColocation("SourceDecodeFilterBin<%=$i%>");
+		config	placement			: partitionColocation("SourceDecodeFilterBin<%=$i%>"), hostColocation("StreamParallelizer<%=$i%>");
 		}
-
-    (stream<emailTuple> filteredEmails<%=$i%>) = emailFilter(emailStream<%=$i%>) {
-//    	config placement			: partitionColocation("filter<%=$i%>");
-		config	placement			: partitionColocation("SourceDecodeFilterBin<%=$i%>");
-    }
-
-    (stream<emailTuple> binEmail<%=$i%>) = emailToBin(filteredEmails<%=$i%>) {
-//    	config placement			: partitionColocation("emailBin<%=$i%>");
-		config	placement			: partitionColocation("SourceDecodeFilterBin<%=$i%>");
-    }
-
-    (stream<emailTuple> modifiedEmails<%=$i%>) = emailModify(binEmail<%=$i%>) {
-    	config placement			: partitionColocation("emailModify<%=$i%>");
-    }
-
-    (stream<$typeOut> metricsOut<%=$i%>) = emailCount(binEmail<%=$i%>) {
-//    	config placement			: partitionColocation("emailCount<%=$i%>");
-    	config placement			: partitionColocation("Metrics");
-    }
-
-    (stream<emailBin> encodedEmail<%=$i%>) = avroEncode(modifiedEmails<%=$i%>) {
-    	config placement			: partitionColocation("avroEncode<%=$i%>");
-    }
 
 	() as Sink<%=$i%> = FileSink(encodedEmail<%=$i%>) {
 
 		param	format				: bin;
-				compression			: gzip;
+//				compression			: gzip;
 				writePunctuations	: true;
 				file				: "/dev/null";
-		config placement			: partitionColocation("FileSink<%=$i%>");
+		config  placement			: partitionColocation("FileSink<%=$i%>"), hostColocation("StreamParallelizer<%=$i%>");
 		}
 
 
 	<%}%>
 
-    stream<$typeOut> out
-     = Filter(metricsOut0
+    stream<emailMetrics> out = Filter(metricsOut0
     <%for(my $i=1; $i<$parallelism; ++$i) {%>
       , metricsOut<%=$i%>
     <%}%>) { config	placement	: partitionColocation("Metrics"); }
@@ -296,6 +273,30 @@ rstring mostFreqWord (list<uint8> bin, <%if($debugCode eq "yes") {%> rstring ema
 //--------------------------- 5. Composite operators ------------------------------//
 //---------------------------------------------------------------------------------//
 
+public composite doTheWork(output encodedEmail, metricsOut; input emailsIn) {
+	graph
+	(stream<emailTuple> emailStream) = avroDecode(emailsIn) {
+	    config threadedPort        : queue(emailsIn,Sys.Wait,5);
+	}
+
+    (stream<emailTuple> filteredEmails) = emailFilter(emailStream) {
+    }
+
+    (stream<emailTuple> binEmail) = emailToBin(filteredEmails) {
+    }
+
+    (stream<emailMetrics> metricsOut) = emailCount(binEmail) {
+    }
+
+    (stream<emailTuple> modifiedEmails) = emailModify(binEmail) {
+    }
+
+    (stream<emailBin> encodedEmail) = avroEncode(modifiedEmails) {
+	    config threadedPort        : queue(modifiedEmails,Sys.Wait,5);
+    }
+}
+
+
 public composite emailFilter(output filteredEmails; input emailsIn) {
 	graph
 		stream<emailTuple> filteredEmails = Custom(emailsIn) {
@@ -314,8 +315,8 @@ public composite emailFilter(output filteredEmails; input emailsIn) {
 												Body = regexReplace(Body, "=\n" , "", true);
 												submit(emailsIn, filteredEmails);
 											}
-
 			}
+			config	threadedPort		: queue(emailsIn, Sys.Wait, 5);
 		}
 }
 
@@ -352,6 +353,7 @@ public composite emailToBin(output convertedEmail; input emailsIn) {
 													//submit({bin=bin}, binEmail);
 													submit(emailsIn, convertedEmail);
 													}
+			config	threadedPort		: queue(emailsIn, Sys.Wait, 5);
 		}
 }
 
@@ -391,7 +393,7 @@ public composite emailModify(output modifiedEmails; input emailsIn) {
 															Body = regexReplace(Body, $NAMES[i] , "Person "
 																					+ (rstring)(i+1), true);
 														}
-														
+
 													}
 
 													submit(emailsIn, modifiedEmails);
@@ -412,7 +414,7 @@ public composite emailModify(output modifiedEmails; input emailsIn) {
 <%}%>
 
 												}
-			//config	threadedPort		: queue(emailsIn, Sys.Wait, 400000);
+			config	threadedPort		: queue(emailsIn, Sys.Wait, 5);
 		}
 }
 
@@ -427,6 +429,7 @@ public composite emailCount(output metricsOut; input binEmail) {
 
 											submit(x, metricsOut);
 					}
+			config	threadedPort		: queue(binEmail, Sys.Wait, 5);
 		}
 }
 


### PR DESCRIPTION
In my runs of the benchmark, the heaviest CPU operators are FileSink, avroEncode and emailModify. The other operators (FileSource, avroDecode, emailFilter, emailToBin, emailCount) are much smaller in CPU.  

Where "%i" is used here to indicate the PARALLELISM=x copy, I've used partitionColocation as "FileSink%i", "emailModify%i", and "avroEncode%i" to group these "heavy" CPU operators into their own PEs.  I grouped the remaining operators together as partitionColocation "SourceDecodeFilterBin%i". 

I added hostColocation "StreamParallelizer%i" to group a flow from FileSource to FileSink all on the same host when running on multi-host instance.  

I also added user-defined parallelism of three around the emailModify operator.  

Taken together, these changes seem to provide a balance such that emailModify, avroEncode and FileSink are all consistently busy and I'm seeing the maximum throughput on a given "PARALLELISM=x" flow.